### PR TITLE
Fix .profile.d $PATH destruction and stderr logging

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -98,7 +98,7 @@ topic "Writing profile script"
 mkdir -p $BUILD_DIR/.profile.d
 
 cat <<EOF > ${BUILD_DIR}/.profile.d/blackfire-agent.sh
-export PATH="/app/${BF_BIN_DIR}:$PATH"
+export PATH="/app/${BF_BIN_DIR}:\$PATH"
 export BLACKFIRE_LOG_FILE="/app/${BF_AGENT_LOG_DIR}/probe.log"
 export BLACKFIRE_LOG_LEVEL=\${BLACKFIRE_LOG_LEVEL:-"1"}
 export BLACKFIRE_COLLECTOR=\${BLACKFIRE_COLLECTOR:-"https://blackfire.io"}

--- a/bin/compile
+++ b/bin/compile
@@ -99,7 +99,7 @@ mkdir -p $BUILD_DIR/.profile.d
 
 cat <<EOF > ${BUILD_DIR}/.profile.d/blackfire-agent.sh
 export PATH="/app/${BF_BIN_DIR}:\$PATH"
-export BLACKFIRE_LOG_FILE="/app/${BF_AGENT_LOG_DIR}/probe.log"
+export BLACKFIRE_LOG_FILE="stderr"
 export BLACKFIRE_LOG_LEVEL=\${BLACKFIRE_LOG_LEVEL:-"1"}
 export BLACKFIRE_COLLECTOR=\${BLACKFIRE_COLLECTOR:-"https://blackfire.io"}
 export BLACKFIRE_ENDPOINT=\${BLACKFIRE_ENDPOINT:-"https://blackfire.io"}
@@ -108,7 +108,7 @@ export BLACKFIRE_AGENT_SOCKET="${BLACKFIRE_AGENT_SOCKET}"
 if [ ! -S ${BF_AGENT_SOCKET_FILE} ] ; then
   blackfire agent:start \
       --config=/app/${BF_AGENT_CONFIG_FILE} \
-      --log-file="/app/${BF_AGENT_LOG_DIR}/agent.log" &
+      --log-file="${BLACKFIRE_LOG_FILE}" &
 fi
 EOF
 


### PR DESCRIPTION
The export statement for `$PATH` in the `.profile.d` script writes the current string literal to the script, rather than a dynamic `$PATH` reference.

This results in all `$PATH` values set at startup in scripts that are sourced before `blackfire-agent.sh` to be wiped away and replaced with the build-time value of `$PATH`.

The agent so far has also been logging to a file, making the logs invisible to `heroku logs`. We hard-code the env var to `stderr` and pass it in explicitly.

Side question: what's the order of precedence for config? Can an env var always override any value, whether set by config file or by command line arg? I'd expect the order, in ascending priority, to be 1) config, 2) env var, 3) cmdline arg, is that correct? (I can update the PR to do this more cleanly once I know the answer).