### PR TITLE
wait for blackfire agent to start on dyno boot

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -112,7 +112,7 @@ if [ ! -S ${BF_AGENT_SOCKET_FILE} ] ; then
   blackfire_pid=\$!
   # give it a moment to start up...
   while ! test -S "${BF_AGENT_SOCKET_FILE}"; do
-    # ...unless it somehow crashes on start, then we have to bail to prevent an infite loop
+    # ...unless it somehow crashes on start, then we have to bail to prevent an infinite loop
     if ! kill -0 \$blackfire_pid 2> /dev/null; then # kill -0 checks if process exists
       echo "Failed to start blackfire agent!" >&2
       break;

--- a/bin/compile
+++ b/bin/compile
@@ -109,6 +109,19 @@ if [ ! -S ${BF_AGENT_SOCKET_FILE} ] ; then
   blackfire agent:start \
       --config=/app/${BF_AGENT_CONFIG_FILE} \
       --log-file="\${BLACKFIRE_LOG_FILE}" &
+  blackfire_pid=\$!
+  # give it a moment to start up...
+  while ! test -S "${BF_AGENT_SOCKET_FILE}"; do
+    # ...unless it somehow crashes on start, then we have to bail to prevent an infite loop
+    if ! kill -0 \$blackfire_pid 2> /dev/null; then # kill -0 checks if process exists
+      echo "Failed to start blackfire agent!" >&2
+      break;
+    fi
+    if [[ "\$BLACKFIRE_LOG_LEVEL" == [34] ]]; then
+      echo "Waiting for blackfire agent..." >&2
+    fi
+    sleep 0.1
+  done
 fi
 EOF
 


### PR DESCRIPTION
This change waits for the socket to be ready before proceeding on dyno boot.

It helps e.g. in scenarios where the agent absolutely must be up, e.g. in testing (for heroku/heroku-buildpack-php).

Our specific use case is that we run a simple command, and assert that the agent starts up (and emits "Waiting for new connection"), but sometimes, the agent takes a little too long to print that, so the command has already finished.

Sure, we could just have a blanket `sleep`, but this can actually also happen with real-life apps, where the PHP extension is then unable to connect to the socket if the agent isn't there.

The same looping logic (except waiting for a PID file, not a socket) is already in place for other background programs in the PHP buildpack on Heroku, and has increased reliability a lot in these "sometimes, the traffic through all these clouds is a little slow") edge cases.

Does this make sense?

(could increase the sleep time to e.g. 0.2 or 0.3 if you're concerned that this spams too many messages; in my tests, there were usually six or seven "Waiting for blackfire agent..." messages on startup, but this is only printed with a suitable log level anyway, and too high a sleep value means "wasting" time on dyno boot as it'll potentially be slow to detect the socket once it's there)